### PR TITLE
added metadata logger

### DIFF
--- a/src/luxonis_train/core/trainer.py
+++ b/src/luxonis_train/core/trainer.py
@@ -34,7 +34,6 @@ class Trainer:
         self.rank = rank_zero_only.rank
 
         cfg_logger = self.cfg.get("logger")
-        hparams = {key: self.cfg.get(key) for key in cfg_logger["logged_hyperparams"]}
 
         load_dotenv()  # loads env variables for mlflow logging
         logger_params = deepcopy(cfg_logger.copy())
@@ -46,7 +45,6 @@ class Trainer:
             ),  # read separately from env vars
             **logger_params,
         )
-        logger.log_hyperparams(hparams)
 
         self.run_save_dir = os.path.join(cfg_logger["save_directory"], logger.run_name)
 

--- a/src/luxonis_train/models/model_lightning_module.py
+++ b/src/luxonis_train/models/model_lightning_module.py
@@ -15,7 +15,11 @@ from luxonis_train.utils.registry import LOSSES, CALLBACKS, OPTIMIZERS, SCHEDULE
 from luxonis_train.utils.metrics import init_metrics
 from luxonis_train.utils.visualization import draw_outputs, draw_labels
 from luxonis_train.utils.filesystem import LuxonisFileSystem
-from luxonis_train.utils.callbacks import AnnotationChecker, ModuleFreezer
+from luxonis_train.utils.callbacks import (
+    AnnotationChecker,
+    ModuleFreezer,
+    MetadataLogger,
+)
 
 
 class ModelLightningModule(pl.LightningModule):
@@ -90,12 +94,15 @@ class ModelLightningModule(pl.LightningModule):
         lr_monitor = LearningRateMonitor(logging_interval="step")
         annotation_checker = AnnotationChecker()
         module_freezer = ModuleFreezer(freeze_info=self.cfg.get("train.freeze_modules"))
+        metadata_logger = MetadataLogger()
+
         callbacks = [
             loss_checkpoint,
             metric_checkpoint,
             lr_monitor,
             annotation_checker,
             module_freezer,
+            metadata_logger,
         ]
 
         # used if we want to perform fine-grained debugging

--- a/src/luxonis_train/utils/callbacks.py
+++ b/src/luxonis_train/utils/callbacks.py
@@ -1,6 +1,10 @@
-from typing import Any, Dict, Optional, List
 import warnings
 import pytorch_lightning as pl
+import pkg_resources
+import os
+import subprocess
+import yaml
+from typing import Any, Dict, Optional, List
 from pytorch_lightning.callbacks import RichProgressBar, BaseFinetuning
 from rich.table import Table
 from torch import Tensor
@@ -129,6 +133,59 @@ class AnnotationChecker(pl.Callback):
         if self.first_test_batch:
             pl_module.model.check_annotations(batch[1])
             self.first_test_batch = False
+
+
+class MetadataLogger(pl.Callback):
+    """Callback that logs all defined hyperparameters together with git hashes if luxonis-ml and luxonis-train
+    packages. Also stores this information locally."""
+
+    def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        from luxonis_train.utils.config import Config
+
+        cfg = Config()
+        hparams = {key: cfg.get(key) for key in cfg.get("logger.logged_hyperparams")}
+
+        # try to get luxonis-ml and luxonis-train git commit hashes (if installed as editable)
+        luxonis_ml_hash = self._get_editable_package_git_hash("luxonis_ml")
+        if luxonis_ml_hash:
+            hparams["luxonis_ml"] = luxonis_ml_hash
+
+        luxonis_train_hash = self._get_editable_package_git_hash("luxonis_train")
+        if luxonis_train_hash:
+            hparams["luxonis_train"] = luxonis_train_hash
+
+        trainer.logger.log_hyperparams(hparams)
+        # also save metadata locally
+        with open(os.path.join(pl_module.save_dir, "metadata.yaml"), "w+") as f:
+            yaml.dump(hparams, f, default_flow_style=False)
+
+    def _get_editable_package_git_hash(self, package_name: str) -> Optional[str]:
+        try:
+            distribution = pkg_resources.get_distribution(package_name)
+            package_location = distribution.location
+
+            # remove any additional folders in path (e.g. "/src")
+            if "src" in package_location:
+                package_location = package_location.replace("src", "")
+
+            # Check if the package location is a Git repository
+            git_dir = os.path.join(package_location, ".git")
+            if os.path.exists(git_dir):
+                git_command = ["git", "rev-parse", "HEAD"]
+                try:
+                    git_hash = subprocess.check_output(
+                        git_command,
+                        cwd=package_location,
+                        stderr=subprocess.DEVNULL,
+                        universal_newlines=True,
+                    ).strip()
+                    return git_hash
+                except subprocess.CalledProcessError:
+                    return None
+            else:
+                return None
+        except pkg_resources.DistributionNotFound:
+            return None
 
 
 class TestOnTrainEnd(pl.Callback):


### PR DESCRIPTION
Added custom `MetadataLogger` callback that logs defined hyperparameter and in addition also logs `luxonis-ml` and `luxonis-train` git commit hashes if these two packages are installed in editable mode. This data is also logged locally as `metadata.yaml` in run directory.